### PR TITLE
docs deployment updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,24 +1,26 @@
+name: "Docs: build and deploy"
+
 on:
-    push:
-        branches:
-            - main
-    pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
-    docs:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-python@v2
-              with:
-                  python-version: 3.8
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
 
-            - name: install mkdocs-material
-              run: pip install mkdocs-material
+      - name: install mkdocs-material
+        run: pip install mkdocs-material
 
-            - name: build docs
-              run: mkdocs build --strict
+      - name: build docs
+        run: mkdocs build --strict
 
-            - name: deploy docs
-              if: github.ref == 'refs/heads/main'
-              run: mkdocs gh-deploy --force
+      - name: deploy docs
+        if: github.ref == 'refs/heads/main'
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,24 @@
 on:
-  push:
-    branches: [ main, develop ]
+    push:
+        branches:
+            - main
+    pull_request:
 
 jobs:
-  deploy_docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy --force
+    docs:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-python@v2
+              with:
+                  python-version: 3.8
+
+            - name: install mkdocs-material
+              run: pip install mkdocs-material
+
+            - name: build docs
+              run: mkdocs build --strict
+
+            - name: deploy docs
+              if: github.ref == 'refs/heads/main'
+              run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,50 +1,51 @@
 site_name: DRESSCode
 site_description: Data Reduction of Extended SWIFT Sources Code
+site_url: https://spacetelescope.github.io/DRESSCode/
 theme:
-  name: material
-  favicon: img/favicon.png
-  logo: img/icon.svg
-  icon:
-    repo: fontawesome/brands/github-alt
-  palette:
-  - media: "(prefers-color-scheme: light)"
-    scheme: default
-    primary: blue
-    accent: indigo
-    toggle:
-      icon: material/lightbulb-outline
-      name: Switch to dark mode
-  - media: "(prefers-color-scheme: dark)"
-    scheme: slate
-    primary: light blue
-    accent: yellow
-    toggle:
-      icon: material/lightbulb
-      name: Switch to light mode
+    name: material
+    favicon: img/favicon.png
+    logo: img/icon.svg
+    icon:
+        repo: fontawesome/brands/github-alt
+    palette:
+        - media: "(prefers-color-scheme: light)"
+          scheme: default
+          primary: blue
+          accent: indigo
+          toggle:
+              icon: material/lightbulb-outline
+              name: Switch to dark mode
+        - media: "(prefers-color-scheme: dark)"
+          scheme: slate
+          primary: light blue
+          accent: yellow
+          toggle:
+              icon: material/lightbulb
+              name: Switch to light mode
 
 nav:
-  - Home: 'index.md'
-  - User Manual: 
-    - user_manual/install.md
-    - user_manual/download_data.md
-    - user_manual/data_reduction_with_dresscode.md
-    - user_manual/notes.md
+    - Home: "index.md"
+    - User Manual:
+          - user_manual/install.md
+          - user_manual/download_data.md
+          - user_manual/data_reduction_with_dresscode.md
+          - user_manual/notes.md
 
 repo_name: spacetelescope/DRESSCode
 repo_url: https://github.com/spacetelescope/DRESSCode
 
 markdown_extensions:
-  - toc:
-      permalink: true
-  - admonition
-  - attr_list
-  - extra
-  - pymdownx.highlight
-  - pymdownx.inlinehilite
-  - pymdownx.superfences
-  - pymdownx.tabbed
+    - toc:
+          permalink: true
+    - admonition
+    - attr_list
+    - extra
+    - pymdownx.highlight
+    - pymdownx.inlinehilite
+    - pymdownx.superfences
+    - pymdownx.tabbed
 
 extra:
-  social:
-    - icon: fontawesome/brands/github-alt
-      link: 'https://github.com/spacetelescope/DRESSCode'
+    social:
+        - icon: fontawesome/brands/github-alt
+          link: "https://github.com/spacetelescope/DRESSCode"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,50 +2,50 @@ site_name: DRESSCode
 site_description: Data Reduction of Extended SWIFT Sources Code
 site_url: https://spacetelescope.github.io/DRESSCode/
 theme:
-    name: material
-    favicon: img/favicon.png
-    logo: img/icon.svg
-    icon:
-        repo: fontawesome/brands/github-alt
-    palette:
-        - media: "(prefers-color-scheme: light)"
-          scheme: default
-          primary: blue
-          accent: indigo
-          toggle:
-              icon: material/lightbulb-outline
-              name: Switch to dark mode
-        - media: "(prefers-color-scheme: dark)"
-          scheme: slate
-          primary: light blue
-          accent: yellow
-          toggle:
-              icon: material/lightbulb
-              name: Switch to light mode
+  name: material
+  favicon: img/favicon.png
+  logo: img/icon.svg
+  icon:
+    repo: fontawesome/brands/github-alt
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: indigo
+      toggle:
+        icon: material/lightbulb-outline
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: light blue
+      accent: yellow
+      toggle:
+        icon: material/lightbulb
+        name: Switch to light mode
 
 nav:
-    - Home: "index.md"
-    - User Manual:
-          - user_manual/install.md
-          - user_manual/download_data.md
-          - user_manual/data_reduction_with_dresscode.md
-          - user_manual/notes.md
+  - Home: "index.md"
+  - User Manual:
+      - user_manual/install.md
+      - user_manual/download_data.md
+      - user_manual/data_reduction_with_dresscode.md
+      - user_manual/notes.md
 
 repo_name: spacetelescope/DRESSCode
 repo_url: https://github.com/spacetelescope/DRESSCode
 
 markdown_extensions:
-    - toc:
-          permalink: true
-    - admonition
-    - attr_list
-    - extra
-    - pymdownx.highlight
-    - pymdownx.inlinehilite
-    - pymdownx.superfences
-    - pymdownx.tabbed
+  - toc:
+      permalink: true
+  - admonition
+  - attr_list
+  - extra
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.tabbed
 
 extra:
-    social:
-        - icon: fontawesome/brands/github-alt
-          link: "https://github.com/spacetelescope/DRESSCode"
+  social:
+    - icon: fontawesome/brands/github-alt
+      link: "https://github.com/spacetelescope/DRESSCode"


### PR DESCRIPTION
- change docs to deploy only on push to main branch (prior to this we were deploying whenever we pushed to `main` or `develop` branches, but not running this action elsewhere.
- change docs to try to build on every PR, so if docs are failing, we will see that in the PR's
- once this is merged, we can re-enable the docs check on our PR's.