### PR TITLE
account for number of finite values (non-nan's) in window when making corrections

### DIFF
--- a/dresscode/corrections.py
+++ b/dresscode/corrections.py
@@ -12,7 +12,12 @@ from typing import Optional, Sequence
 import numpy as np
 from astropy.io import fits
 
-from dresscode.utils import load_config, windowed_std, windowed_sum
+from dresscode.utils import (
+    load_config,
+    windowed_finite_vals,
+    windowed_std,
+    windowed_sum,
+)
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -77,7 +82,7 @@ def coicorr(filename):
     # Sum the flux densities (count rates) of the 9x9 surrounding pixels: Craw (counts/s).
     size = 9
     radius = (size - 1) // 2
-    window_pixels = size**2
+    window_pixels = windowed_finite_vals(data, radius)
     total_flux = windowed_sum(data, radius)
 
     # standard deviation of the flux densities in the 9x9 pixels box.

--- a/dresscode/corrections.py
+++ b/dresscode/corrections.py
@@ -86,7 +86,7 @@ def coicorr(filename):
     total_flux = windowed_sum(data, radius)
 
     # standard deviation of the flux densities in the 9x9 pixels box.
-    std = windowed_std(data, radius)
+    std = windowed_std(data, radius, win_finite_vals=window_pixels)
 
     # Obtain the dead time correction factor and the frame time (in s) from the header
     # of the image.

--- a/dresscode/utils.py
+++ b/dresscode/utils.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
+from typing import Optional
 
 import numpy as np
-from scipy.ndimage import convolve
+from astropy.convolution import convolve
 
 
 def listdir_nohidden(path):
@@ -35,10 +38,20 @@ def windowed_sum(arr: np.ndarray, radius: int) -> np.ndarray:
     """
 
     kernel = np.ones((radius * 2 + 1, radius * 2 + 1), dtype=int)
-    return convolve(arr, kernel, mode="constant", cval=0.0)
+    return convolve(
+        arr,
+        kernel,
+        boundary="fill",
+        fill_value=0.0,
+        nan_treatment="fill",
+        normalize_kernel=False,
+        preserve_nan=True,
+    )
 
 
-def windowed_var(arr: np.ndarray, radius: int) -> np.ndarray:
+def windowed_var(
+    arr: np.ndarray, radius: int, win_finite_vals: Optional[np.ndarray] = None
+) -> np.ndarray:
     """Calculate the variance of a window around each pixel in an array
     Adapted from the this SO: https://stackoverflow.com/a/18423835/532963
     We use our windowed_sum convolution calc. which can handle nan's
@@ -49,22 +62,24 @@ def windowed_var(arr: np.ndarray, radius: int) -> np.ndarray:
 
     Note: this returns smaller in size than the input array (by radius)
     """
-    diameter = radius * 2 + 1
-    win_sum = windowed_sum(arr, radius)[radius:-radius, radius:-radius]
-    win_sum_2 = windowed_sum(arr * arr, radius)[radius:-radius, radius:-radius]
-    return (win_sum_2 - win_sum * win_sum / diameter / diameter) / diameter / diameter
+
+    if win_finite_vals is None:
+        win_finite_vals = windowed_finite_vals(arr, radius)
+    win_sum = windowed_sum(arr, radius)
+    win_sum_2 = windowed_sum(arr * arr, radius)
+    output = (win_sum_2 - win_sum * win_sum / win_finite_vals) / win_finite_vals
+    return output
 
 
-def windowed_std(arr: np.ndarray, radius: int) -> np.ndarray:
+def windowed_std(
+    arr: np.ndarray, radius: int, win_finite_vals: Optional[np.ndarray] = None
+) -> np.ndarray:
     """Standard deviation around a radius of each elemnt in an array"""
 
-    output = np.full_like(arr, np.nan, dtype=np.float64)
-
-    var_arr = windowed_var(arr, radius)
+    var_arr = windowed_var(arr, radius, win_finite_vals)
     std_arr = np.sqrt(var_arr)
-    output[radius:-radius, radius:-radius] = std_arr
 
-    return output
+    return std_arr
 
 
 def windowed_finite_vals(arr: np.ndarray, radius: int) -> np.ndarray:

--- a/dresscode/utils.py
+++ b/dresscode/utils.py
@@ -65,3 +65,12 @@ def windowed_std(arr: np.ndarray, radius: int) -> np.ndarray:
     output[radius:-radius, radius:-radius] = std_arr
 
     return output
+
+
+def windowed_finite_vals(arr: np.ndarray, radius: int) -> np.ndarray:
+    """Number of finite values around a radius of each element in an array"""
+
+    finite_arr = np.isfinite(arr).astype(int)
+    output = windowed_sum(finite_arr, radius)
+
+    return output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,6 +45,28 @@ def windowed_std_loop(arr: np.ndarray, radius: int, ddof=0) -> np.ndarray:
     return output
 
 
+def windowed_finite_vals_loop(arr: np.ndarray, radius: int) -> np.ndarray:
+    """Number of finite values around a radius of each element in an array
+
+    only for comparison / equivalence testing
+
+    Implementation: iteration"""
+
+    output = np.full_like(arr, np.nan, dtype=np.float64)
+
+    for y in range(arr.shape[0]):
+        for x in range(arr.shape[1]):
+            output[y, x] = np.sum(
+                np.isfinite(
+                    arr[
+                        max(0, y - radius) : min(y + radius + 1, arr.shape[0]),
+                        max(0, x - radius) : min(x + radius + 1, arr.shape[1]),
+                    ]
+                )
+            )
+    return output
+
+
 # test data
 
 input_3_3 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=np.float64)
@@ -202,3 +224,23 @@ def test_std_nan_data():
     output_loop = windowed_std_loop(data, 1)
     test_output = utils.windowed_std(data, 1)
     assert np.allclose(output_loop, test_output, equal_nan=True)
+
+
+def test_windowed_finite_vals():
+    data = np.random.random((10, 10))
+    data[3:4, 3:4] = np.nan
+    output_loop = windowed_finite_vals_loop(data, 1)
+    test_output = utils.windowed_finite_vals(data, 1)
+    assert np.array_equal(output_loop, test_output)
+
+
+def test_windowed_finite_vals_larger_arr():
+    data = np.random.random((45, 50))
+    # throw in some nan's
+    nan_indices_y = np.random.choice(np.arange(45), size=10, replace=False)
+    nan_indices_x = np.random.choice(np.arange(50), size=10, replace=False)
+    data[nan_indices_y, nan_indices_x] = np.nan
+
+    output_loop = windowed_finite_vals_loop(data, 1)
+    test_output = utils.windowed_finite_vals(data, 1)
+    assert np.array_equal(output_loop, test_output)


### PR DESCRIPTION
we were using a fixed value for the number of pixels in a window for calc coincidence loss corrections (e.g. for a size of `9`, we used `81`)

It is more accurate, for the calculation of coincidence loss correction factor and the relative uncertainty, to account for the actual number of finite values used in making the correction, within the window.

this MR changes the static value to an array, which represents the number of finite values used in summing.

~however, since we currently calculate the std in a way in which nan's propagate out to fill the window, I believe using an array here has no effect, since any value less than 81 was going to be ignored (mult. by a `nan`)~

This utility function, though, has virtually no cost, it's extremely fast to calculate, and it may have some use in the future, as we rearrange the step order, and need to perform normalizations several times.

~Also, we _could_ consider calculating the standard deviation around the edges, and just using the correct denominator here for number for the window size.~

EDIT:

I made the modifications to include the edges in our sum and std calculations, using astropy's convolve function, which supports NaN's. If a value in a window includes a NaN, we still calculate the sum and std, unless the center value actually is NaN, in which case we preserve it.  This helps avoid large "holes" whenever an NaN (bad pixel) occurs.

E.g. 

```python
>>> np.random.seed(0)
>>> data = np.random.random((4, 4))
>>> data[2, 2] = np.nan
>>> data
array([[0.55, 0.72, 0.6 , 0.54],
       [0.42, 0.65, 0.44, 0.89],
       [0.96, 0.38,  nan, 0.53],
       [0.57, 0.93, 0.07, 0.09]])
>>> radius = 2
```

before: 

```python
>>> utils.windowed_sum(data, radius)
array([[nan, nan, nan, nan],
       [nan, nan, nan, nan],
       [nan, nan, nan, nan],
       [nan, nan, nan, nan]])
>>> utils.windowed_std(data, radius)
array([[nan, nan, nan, nan],
       [nan, nan, nan, nan],
       [nan, nan, nan, nan],
       [nan, nan, nan, nan]])
```

after:

```python
>>> utils.windowed_sum(data, 1)
>>> utils.windowed_sum(data, radius)
array([[4.72, 6.69, 6.69, 4.75],
       [6.29, 8.34, 8.34, 5.83],
       [6.29, 8.34,  nan, 5.83],
       [4.42, 5.93, 5.93, 3.97]])
>>> utils.windowed_std(data, radius)
array([[0.18, 0.18, 0.18, 0.15],
       [0.24, 0.25, 0.25, 0.27],
       [0.24, 0.25,  nan, 0.27],
       [0.28, 0.29, 0.29, 0.3 ]])
```