### PR TITLE
update wcstools 3.9.7

### DIFF
--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -33,11 +33,17 @@ jobs:
       - name: Build the dependency Docker image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build --pull --tag dresscodeswift/heasoft-caldb-wcstools:latest -f Docker/heasoft-caldb-wcstools.dockerfile .
+          docker pull dresscodeswift/heasoft-caldb-wcstools:latest
+          docker build --tag dresscodeswift/heasoft-caldb-wcstools:latest \
+            --cache-from dresscodeswift/heasoft-caldb-wcstools:latest \
+            -f Docker/heasoft-caldb-wcstools.dockerfile .
 
       - name: Build the DRESSCode Docker image
         run: |
-          docker build --pull --tag dresscodeswift/dresscode:latest -f Docker/dockerfile .
+          docker pull dresscodeswift/dresscode:latest
+          docker build --tag dresscodeswift/dresscode:latest \
+          --cache-from dresscodeswift/dresscode:latest \
+          -f Docker/dockerfile .
 
       - name: Run the pipeline
         run: |

--- a/Docker/heasoft-caldb-wcstools.dockerfile
+++ b/Docker/heasoft-caldb-wcstools.dockerfile
@@ -16,14 +16,14 @@ RUN \
 USER heasoft
 
 ENV CALDB=/opt/heasoft/caldb \
-    PATH=/opt/heasoft/wcstools-3.9.6/bin:$PATH
+    PATH=/opt/heasoft/wcstools-3.9.7/bin:$PATH
 
 RUN \
     # get/make wcstools
-    wget --no-verbose tdc-www.harvard.edu/software/wcstools/wcstools-3.9.6.tar.gz \
-    && tar -xf wcstools-3.9.6.tar.gz -C /opt/heasoft \
-    && rm wcstools-3.9.6.tar.gz \
-    && cd /opt/heasoft/wcstools-3.9.6 \
+    wget --no-verbose tdc-www.harvard.edu/software/wcstools/wcstools-3.9.7.tar.gz \
+    && tar -xf wcstools-3.9.7.tar.gz -C /opt/heasoft \
+    && rm wcstools-3.9.7.tar.gz \
+    && cd /opt/heasoft/wcstools-3.9.7 \
     && make all \
     # get caldb
     && cd $CALDB \

--- a/Docker/heasoft-caldb-wcstools.dockerfile
+++ b/Docker/heasoft-caldb-wcstools.dockerfile
@@ -16,14 +16,15 @@ RUN \
 USER heasoft
 
 ENV CALDB=/opt/heasoft/caldb \
-    PATH=/opt/heasoft/wcstools-3.9.7/bin:$PATH
+    WCSTOOL_VER=3.9.7 \
+    PATH=/opt/heasoft/wcstools-${WCSTOOL_VER}/bin:$PATH
 
 RUN \
     # get/make wcstools
-    wget --no-verbose tdc-www.harvard.edu/software/wcstools/wcstools-3.9.7.tar.gz \
-    && tar -xf wcstools-3.9.7.tar.gz -C /opt/heasoft \
-    && rm wcstools-3.9.7.tar.gz \
-    && cd /opt/heasoft/wcstools-3.9.7 \
+    wget --no-verbose tdc-www.harvard.edu/software/wcstools/wcstools-${WCSTOOL_VER}.tar.gz || wget --no-verbose tdc-www.harvard.edu/software/wcstools/Old/wcstools-${WCSTOOL_VER}.tar.gz \
+    && tar -xf wcstools-${WCSTOOL_VER}.tar.gz -C /opt/heasoft \
+    && rm wcstools-${WCSTOOL_VER}.tar.gz \
+    && cd /opt/heasoft/wcstools-${WCSTOOL_VER} \
     && make all \
     # get caldb
     && cd $CALDB \

--- a/Docker/heasoft-caldb-wcstools.dockerfile
+++ b/Docker/heasoft-caldb-wcstools.dockerfile
@@ -3,21 +3,19 @@ FROM dresscodeswift/heasoft:v6.28.swift
 USER root
 
 RUN \
-    apt-get update \
-    && apt-get -y upgrade \
-    && apt-get -y install \
+    apt-get update && apt-get upgrade --yes \
+    && apt-get install --yes --no-install-recommends \
     python3-pip \
     python3-venv \
     python3-dev \
     git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER heasoft
 
-ENV CALDB=/opt/heasoft/caldb \
-    WCSTOOL_VER=3.9.7 \
-    PATH=/opt/heasoft/wcstools-${WCSTOOL_VER}/bin:$PATH
+ENV CALDB=/opt/heasoft/caldb
+ENV WCSTOOL_VER=3.9.7
+ENV PATH=/opt/heasoft/wcstools-$WCSTOOL_VER/bin:$PATH
 
 RUN \
     # get/make wcstools
@@ -36,8 +34,8 @@ RUN \
     && rm goodfiles_swift_uvota.tar.Z \
     && caldbinfo INST swift uvota \
     && /bin/echo 'export CALDB='$CALDB >> /home/heasoft/.profile \
-    && /bin/echo "source $CALDB/software/tools/caldbinit.sh" >> /home/heasoft/.profile \
+    && /bin/echo "source $CALDB/caldbinit.sh" >> /home/heasoft/.profile \
     && /bin/echo 'export CALDB='$CALDB >> /home/heasoft/.bashrc \
-    && /bin/echo "source $CALDB/software/tools/caldbinit.sh" >> /home/heasoft/.bashrc \
+    && /bin/echo "source $CALDB/caldbinit.sh" >> /home/heasoft/.bashrc \
     && /bin/echo 'setenv CALDB '$CALDB >> /home/heasoft/.cshrc \
-    && /bin/echo "source $CALDB/software/tools/caldbinit.csh" >> /home/heasoft/.cshrc
+    && /bin/echo "source $CALDB/caldbinit.csh" >> /home/heasoft/.cshrc

--- a/docs/install.md
+++ b/docs/install.md
@@ -52,19 +52,19 @@ All subsequent steps are for Ubuntu platforms:
 
 ### Install wcstools
 
-1. Download the current version (3.9.6) from <http://tdc-www.harvard.edu/software/wcstools/wcstools-3.9.6.tar.gz>
+1. Download the current version (3.9.7) from <http://tdc-www.harvard.edu/software/wcstools/wcstools-3.9.7.tar.gz>
 2. Put the tarfile in your home folder and untar
 3. Install the tools:
 
     ```sh
-    cd wcstools-3.9.6
+    cd wcstools-3.9.7
     make all
     ```
 
 4. Add the following line to your `.bashrc` (or equivalent):
 
     ```sh
-    export PATH=~/wcstools-3.9.6/bin:$PATH
+    export PATH=~/wcstools-3.9.7/bin:$PATH
     ```
 
 More info can be found on the wcstools <a href="http://tdc-www.harvard.edu/wcstools/" target="_blank">website</a>.


### PR DESCRIPTION
updates wcstools from 3.9.6 to 3.9.7

needed for successful docker build because when they release a new version, the link to the old version is broken.

can still get to the old version, but have to add "Old" path to the url.

e.g. http://tdc-www.harvard.edu/software/wcstools/Old/wcstools-3.9.6.tar.gz

I've made the docker build command a little more robust, in that it will first try the newest url and if that fails it will look for the software in the "Old" path.

this also fixes an issue with caldb path changes